### PR TITLE
chore: login now sends error messages

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -5,7 +5,6 @@ import { Form } from "@remix-run/react";
 import { authenticator } from "~/utils/auth.server";
 
 // TODO: Improve README instructions and description
-// TODO: Improve error handling on login page
 
 export const meta: MetaFunction = () => {
   return [

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -1,8 +1,8 @@
-import { Authenticator, AuthorizationError } from "remix-auth"
-import { sessionStorage } from "./session.server"
-import { FormStrategy } from "remix-auth-form"
-import { prisma } from './prisma.server'
-import bcrypt from "bcryptjs"
+import { Authenticator } from "remix-auth";
+import { sessionStorage } from "./session.server";
+import { FormStrategy } from "remix-auth-form";
+import { prisma } from './prisma.server';
+import bcrypt from "bcryptjs";
 
 const sessionSecret = process.env.SESSION_SECRET;
 
@@ -10,33 +10,34 @@ if (!sessionSecret) {
   throw new Error("SESSION_SECRET must be set");
 }
 
-const authenticator = new Authenticator<any>(sessionStorage)
+const authenticator = new Authenticator<any>(sessionStorage);
 
-const formStrategy = new FormStrategy(async ({form}) => {
-    const email = form.get("email") as string
-    const password = form.get("password") as string
-  
-    const user = await prisma.user.findUnique({
-      where: { email },
-    });
-  
-    if (!user) {
-      console.log("you entered a wrong email")
-      throw new AuthorizationError()
-    }
-  
-    const passwordsMatch = await bcrypt.compare(
-      password,
-      user.password as string,
-    )
-  
-    if (!passwordsMatch) {
-      throw new AuthorizationError()
-    }
-  
-    return user
-})
+const formStrategy = new FormStrategy(async ({ form }) => {
+  const email = form.get("email") as string;
+  const password = form.get("password") as string;
 
-authenticator.use(formStrategy, "form")
+  const user = await prisma.user.findUnique({
+    where: { email },
+  });
 
-export {authenticator}
+  if (!user) {
+    console.log("Invalid email");
+    return { success: false, message: "Invalid email." };
+  }
+
+  const passwordsMatch = await bcrypt.compare(
+    password,
+    user.password as string,
+  );
+
+  if (!passwordsMatch) {
+    console.log("Invalid password");
+    return { success: false, message: "Invalid password." };
+  }
+
+  return { success: true, user };
+});
+
+authenticator.use(formStrategy, "form");
+
+export { authenticator };


### PR DESCRIPTION
# chore: login now sends error messages
Previous implementation only logged errors in the console. Now the user can see error messages. Exact error messages is TBD based on app. Not telling the user if password or email is wrong would protect against attackers.

## Before
_Was the same but would just reload login_

## After:
![Login Error logging after](https://github.com/user-attachments/assets/3b0ecf09-de74-4d73-98f3-07576d36a2ee)
