### PR TITLE
chore: login error handling and prettier fixes

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,13 +6,13 @@ import type {
 import { Form, useLoaderData } from "@remix-run/react";
 import { Taskform } from "~/components/taskform";
 import { Tasklist, TaskListProps } from "~/components/tasklist";
-import { Layout } from "~/root";
 
 import { authenticator } from "~/utils/auth.server";
 import { createTask, deleteTask, getMyTasks } from "~/utils/tasks.server";
 
 // TODO: Improve README instructions and description
 // TODO: TS unit tests
+// TODO: Email and password validation
 
 export const meta: MetaFunction = () => {
   return [

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -2,75 +2,118 @@ import React, { useState } from "react";
 import { Layout } from "../components/layout";
 import { Textfield } from "~/components/textField";
 import { Link, useActionData } from "@remix-run/react";
-import { LoaderFunction, ActionFunction, json, redirect, MetaFunction } from "@remix-run/node";
+import {
+  LoaderFunction,
+  ActionFunction,
+  json,
+  MetaFunction,
+} from "@remix-run/node";
+import { authUser } from "~/utils/user.server";
 
 import { authenticator } from "~/utils/auth.server";
 
 export const meta: MetaFunction = () => {
-    return [{ title: "New Remix App Login" }];
+  return [{ title: "New Remix App Login" }];
 };
 
 export const loader: LoaderFunction = async ({ request }) => {
-    const user = await authenticator.isAuthenticated(request, {
-      successRedirect: "/",
-    })
-    return user
-  }
-  
-  export const action: ActionFunction = async ({ request }) => {
-    return authenticator.authenticate("form", request, {
-      successRedirect: "/",
-      failureRedirect: "/login",
-    })
+  const user = await authenticator.isAuthenticated(request, {
+    successRedirect: "/",
+  });
+  return user;
+};
+
+export const action: ActionFunction = async ({ request }) => {
+  const requestClone = request.clone(); // Cloning the request
+  const formData = await requestClone.formData();
+
+  const email = formData.get("email") as string;
+  const password = formData.get("password") as string;
+
+  const result = await authUser({ email, password });
+
+  if (!email || !password) {
+    return json(
+      { error: `All fields are required`, form: action },
+      { status: 400 }
+    );
   }
 
+  if (!result.success) {
+    return json({ error: result.message }, { status: 400 });
+  }
+
+  return await authenticator.authenticate("form", request, {
+    successRedirect: "/",
+    failureRedirect: "/login",
+    context: { formData: formData },
+  });
+};
+
 interface ActionData {
-    fields?: {
-        email?: string;
-        password?: string;
-    };
-    error?: string;
+  fields?: {
+    email?: string;
+    password?: string;
+  };
+  error?: string;
 }
 
 export default function Login() {
-    const actionData = useActionData<ActionData>();
-    const [formData, setFormData] = useState({
-        email: actionData?.fields?.email || '',
-        password: actionData?.fields?.password || '',
-    });
+  const actionData = useActionData<ActionData>();
+  const [formData, setFormData] = useState({
+    email: actionData?.fields?.email || "",
+    password: actionData?.fields?.password || "",
+  });
 
-    // Updates the form data when an input changes
-    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>, field: string) => {
-        setFormData(form => ({ ...form, [field]: event.target.value }));
-    };
+  // Updates the form data when an input changes
+  const handleInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    field: string
+  ) => {
+    setFormData((form) => ({ ...form, [field]: event.target.value }));
+  };
 
-    return (
-        <Layout>
-            <div className="h-full justify-center bg-sky-400 items-center flex flex-col gap-y-5">
-                <form method="POST" className="rounded-lg bg-white p-6 w-96">
-                    <h2 className="text-3xl font-bold text-gray-400 mb-5 flex flex-col items-center">Login</h2>
-                    {actionData?.error && <p className="text-left ml-1 text-red-500">{actionData.error}</p>}
-                    <Textfield
-                        htmlFor="email"
-                        placeholder="Email"
-                        value={formData.email}
-                        onChange={e => handleInputChange(e, 'email')}
-                    />
-                    <Textfield
-                        htmlFor="password"
-                        type="password"
-                        placeholder="Password"
-                        value={formData.password}
-                        onChange={e => handleInputChange(e, 'password')}
-                    />
-                    <div className="w-full text-center mt-5">
-                        <button type="submit" name="_action" value="Sign In" className="w-full rounded-xl mt-2 bg-sky-400 px-3 py-2 text-white font-semibold transition duration-300 ease-in-out hover:bg-sky-600">
-                            Login
-                        </button>
-                    </div>
-                </form>
-                <p className="text-white">Don't have an account? <Link to="/signup"><span className="text-white px-2 underline">Signup</span></Link></p>
-            </div>
-        </Layout>
-    );
+  return (
+    <Layout>
+      <div className="h-full justify-center bg-sky-400 items-center flex flex-col gap-y-5">
+        <form method="POST" className="rounded-lg bg-white p-6 w-96">
+          <h2 className="text-3xl font-bold text-gray-400 mb-5 flex flex-col items-center">
+            Login
+          </h2>
+          {actionData?.error && (
+            <p className="text-left ml-1 text-red-500">{actionData.error}</p>
+          )}
+          <Textfield
+            htmlFor="email"
+            placeholder="Email"
+            value={formData.email}
+            onChange={(e) => handleInputChange(e, "email")}
+          />
+          <Textfield
+            htmlFor="password"
+            type="password"
+            placeholder="Password"
+            value={formData.password}
+            onChange={(e) => handleInputChange(e, "password")}
+          />
+          <div className="w-full text-center mt-5">
+            <button
+              type="submit"
+              name="_action"
+              value="Sign In"
+              className="w-full rounded-xl mt-2 bg-sky-400 px-3 py-2 text-white font-semibold transition duration-300 ease-in-out hover:bg-sky-600"
+            >
+              Login
+            </button>
+          </div>
+        </form>
+        <p className="text-white">
+          Don't have an account?{" "}
+          <Link to="/signup">
+            <span className="text-white px-2 underline">Signup</span>
+          </Link>
+        </p>
+      </div>
+    </Layout>
+  );
 }

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -1,107 +1,131 @@
 import React, { useState } from "react";
 import { Link, useActionData } from "@remix-run/react";
-import { LoaderFunction, ActionFunction, json, MetaFunction } from "@remix-run/node";
+import {
+  LoaderFunction,
+  ActionFunction,
+  json,
+  MetaFunction,
+} from "@remix-run/node";
 
 import { authenticator } from "~/utils/auth.server";
-import { createUser } from "~/utils/user.server"; 
+import { createUser } from "~/utils/user.server";
 
 import { Layout } from "../components/layout";
 import { Textfield } from "~/components/textField";
 
 export const meta: MetaFunction = () => {
-    return [{ title: "New Remix App Signup" }];
+  return [{ title: "New Remix App Signup" }];
 };
 
 export const loader: LoaderFunction = async ({ request }) => {
-    const user = await authenticator.isAuthenticated(request, {
-        successRedirect: "/"
-    })
-    return { user }
+  const user = await authenticator.isAuthenticated(request, {
+    successRedirect: "/",
+  });
+  return { user };
 };
 
 export const action: ActionFunction = async ({ request }) => {
-    const requestClone = request.clone(); // Cloning the request
-    const formData = await requestClone.formData();
-    const action = formData.get("_action") as string;
-    const email = formData.get("email") as string;
-    const password = formData.get("password") as string;
-    const name = formData.get("name") as string;
+  const requestClone = request.clone(); // Cloning the request
+  const formData = await requestClone.formData();
+  const action = formData.get("_action") as string;
+  const email = formData.get("email") as string;
+  const password = formData.get("password") as string;
+  const name = formData.get("name") as string;
 
-    if (!email || !password || !name) {
-        return json({ error: `All fields are required`, form: action }, { status: 400 });
-      }
+  if (!email || !password || !name) {
+    return json(
+      { error: `All fields are required`, form: action },
+      { status: 400 }
+    );
+  }
 
-      const result = await createUser({email, password, name});
+  const result = await createUser({ email, password, name });
 
-      if (!result.success) {
-        return json({ error: result.message }, { status: 400 });
-      }
+  if (!result.success) {
+    return json({ error: result.message }, { status: 400 });
+  }
 
-    return await authenticator.authenticate("form", request, {
-        successRedirect: "/",
-        failureRedirect: "/signup",
-        context: {formData: formData},
-    })
+  return await authenticator.authenticate("form", request, {
+    successRedirect: "/",
+    failureRedirect: "/signup",
+    context: { formData: formData },
+  });
 };
 
 interface ActionData {
-    fields?: {
-        email?: string;
-        password?: string;
-        name?: string;
-    };
-    error?: string;
+  fields?: {
+    email?: string;
+    password?: string;
+    name?: string;
+  };
+  error?: string;
 }
 
-
 export default function SignUp() {
-    const actionData = useActionData<ActionData>();
-    const [formData, setFormData] = useState({
-        email: actionData?.fields?.email || '',
-        password: actionData?.fields?.password || '',
-        name: actionData?.fields?.name || '',
-    });
+  const actionData = useActionData<ActionData>();
+  const [formData, setFormData] = useState({
+    email: actionData?.fields?.email || "",
+    password: actionData?.fields?.password || "",
+    name: actionData?.fields?.name || "",
+  });
 
-    // Updates the form data when an input changes
-    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>, field: string) => {
-        event.preventDefault();
-        setFormData(form => ({ ...form, [field]: event.target.value }));
-    };
+  // Updates the form data when an input changes
+  const handleInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    field: string
+  ) => {
+    event.preventDefault();
+    setFormData((form) => ({ ...form, [field]: event.target.value }));
+  };
 
-    return (
-        <Layout>
+  return (
+    <Layout>
       <div className="h-full justify-center bg-sky-400 items-center flex flex-col gap-y-5">
         <form method="POST" className="rounded-lg bg-white p-5 w-96">
-          <h2 className="text-3xl font-bold text-gray-400 mb-2 flex flex-col items-center">Create an account</h2>
-          {actionData?.error && <p className="text-left ml-1 text-red-500">{actionData.error}</p>}
+          <h2 className="text-3xl font-bold text-gray-400 mb-2 flex flex-col items-center">
+            Create an account
+          </h2>
+          {actionData?.error && (
+            <p className="text-left ml-1 text-red-500">{actionData.error}</p>
+          )}
           <Textfield
             htmlFor="name"
             type="name"
             placeholder="Name"
             value={formData.name}
-            onChange={e => handleInputChange(e, 'name')}
+            onChange={(e) => handleInputChange(e, "name")}
           />
           <Textfield
             htmlFor="email"
             placeholder="Email"
             value={formData.email}
-            onChange={e => handleInputChange(e, 'email')}
+            onChange={(e) => handleInputChange(e, "email")}
           />
           <Textfield
             htmlFor="password"
             type="password"
             placeholder="Password"
             value={formData.password}
-            onChange={e => handleInputChange(e, 'password')}
+            onChange={(e) => handleInputChange(e, "password")}
           />
           <div className="w-full text-center mt-2">
-            <button type="submit" name="_action" value="Sign In" className="w-full rounded-xl bg-sky-400 px-3 py-2 text-white font-semibold transition duration-300 ease-in-out hover:bg-sky-600">
+            <button
+              type="submit"
+              name="_action"
+              value="Sign In"
+              className="w-full rounded-xl bg-sky-400 px-3 py-2 text-white font-semibold transition duration-300 ease-in-out hover:bg-sky-600"
+            >
               Create an account
             </button>
           </div>
         </form>
-        <p className="text-white">Already have an account?<Link to="/login"><span className="text-white px-2 underline">Sign In</span></Link></p>
+        <p className="text-white">
+          Already have an account?
+          <Link to="/login">
+            <span className="text-white px-2 underline">Sign In</span>
+          </Link>
+        </p>
       </div>
     </Layout>
-    )
+  );
 }

--- a/app/utils/types.server.ts
+++ b/app/utils/types.server.ts
@@ -3,3 +3,8 @@ export type RegisterForm = {
   password: string
   name: string
 }
+
+export type LoginForm = {
+  email: string
+  password: string
+}

--- a/app/utils/user.server.ts
+++ b/app/utils/user.server.ts
@@ -1,5 +1,5 @@
 import bcrypt from 'bcryptjs'
-import type { RegisterForm } from './types.server'
+import type { LoginForm, RegisterForm } from './types.server'
 import { prisma } from './prisma.server'
 import { Prisma } from '@prisma/client';
 
@@ -21,4 +21,28 @@ export const createUser = async (user: RegisterForm) => {
     }
     return { success: false, message: 'Failed to create user account.' };
   }
+}
+
+export const authUser = async (user: LoginForm) => {
+  const email = user.email as string
+  const password = user.password as string
+
+  const potentialUser = await prisma.user.findUnique({
+    where: { email },
+  });
+
+  if (!potentialUser) {
+    return { success: false, message: "Could not find an account with this email." }
+  }
+
+  const passwordsMatch = await bcrypt.compare(
+    password,
+    potentialUser.password as string,
+  )
+
+  if (!passwordsMatch) {
+    return { success: false, message: "Incorrect password entered." }
+  }
+
+  return { success: true, message: "" };
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "remix vite:dev",
     "lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
     "start": "remix-serve ./build/server/index.js",
-    "typecheck": "tsc"
+    "types": "tsc"
   },
   "dependencies": {
     "@prisma/client": "^5.18.0",


### PR DESCRIPTION
Error handling had to be reversed to stop the user from going to main page without logging in. Was able to get a workaround by adapting the "createUser" functionality into a authUser function.
 
Naming could be changed to "loginUser", "verifyUser" ?? 

Now:
![Login Error logging redone](https://github.com/user-attachments/assets/8521d850-ecd5-4dd0-b12b-122c199f3eb7)
